### PR TITLE
Adaptation to root5 and convenience runAnalysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,15 @@
 *.root
 *.xml
 *.pcm
+*.sh
+*.jdl
+
+.cproject
+.project
+
+
+myAnalysis.C
+myTask_merge.C
+outputs_valid
+stderr
+

--- a/AddMyTask.C
+++ b/AddMyTask.C
@@ -1,5 +1,7 @@
+#if !defined (__CINT__) || defined (__CLING__)
 #include "AliAnalysisManager.h"
 #include "AliAnalysisTaskMyTask.h"
+#endif
 
 AliAnalysisTaskMyTask* AddMyTask(TString name = "name")
 {

--- a/AddMyTask.C
+++ b/AddMyTask.C
@@ -1,3 +1,6 @@
+#include "AliAnalysisManager.h"
+#include "AliAnalysisTaskMyTask.h"
+
 AliAnalysisTaskMyTask* AddMyTask(TString name = "name")
 {
     // get the manager via the static access member. since it's static, you don't need

--- a/AliAnalysisTaskMyTask.cxx
+++ b/AliAnalysisTaskMyTask.cxx
@@ -23,6 +23,7 @@
 #include "TH1F.h"
 #include "TList.h"
 #include "AliAnalysisTask.h"
+#include "AliAnalysisTaskSE.h"
 #include "AliAnalysisManager.h"
 #include "AliAODEvent.h"
 #include "AliAODInputHandler.h"

--- a/AliAnalysisTaskMyTask.h
+++ b/AliAnalysisTaskMyTask.h
@@ -5,7 +5,9 @@
 #ifndef AliAnalysisTaskMyTask_H
 #define AliAnalysisTaskMyTask_H
 
+#if !defined (__CINT__) || defined (__CLING__)
 #include "AliAnalysisTaskSE.h"
+#endif
 
 class AliAnalysisTaskMyTask : public AliAnalysisTaskSE  
 {

--- a/runAnalysis.C
+++ b/runAnalysis.C
@@ -1,14 +1,18 @@
+#include "TROOT.h"
+#include "TSystem.h"
+#if !defined (__CINT__) || defined (__CLING__)
 #include "TInterpreter.h"
 #include "TChain.h"
 #include "AliAnalysisAlien.h"
 #include "AliAnalysisManager.h"
 #include "AliAODInputHandler.h"
-
 // include the header of your analysis task here! for classes already compiled by aliBuild,
 // precompiled header files (with extension pcm) are available, so that you do not need to
 // specify includes for those. for your own task however, you (probably) have not generated a
 // pcm file, so we need to include it explicitly
 #include "AliAnalysisTaskMyTask.h"
+#endif
+
 
 // run your analysis in the mode 'mode'
 // if 'mode' is 'grid' the results will be merged via jdl on the grid if gridMerge is true

--- a/runAnalysis.C
+++ b/runAnalysis.C
@@ -1,15 +1,32 @@
+#include "TInterpreter.h"
+#include "TChain.h"
+#include "AliAnalysisAlien.h"
+#include "AliAnalysisManager.h"
+#include "AliAODInputHandler.h"
+
 // include the header of your analysis task here! for classes already compiled by aliBuild,
 // precompiled header files (with extension pcm) are available, so that you do not need to
 // specify includes for those. for your own task however, you (probably) have not generated a
 // pcm file, so we need to include it explicitly
 #include "AliAnalysisTaskMyTask.h"
 
-void runAnalysis()
+// run your analysis in the mode 'mode'
+// if 'mode' is 'grid' the results will be merged via jdl on the grid if gridMerge is true
+// available modes: "grid", "local", "test", "terminate"
+// mode "grid" : self-explained
+// mode "local" : expects an AliAOD.root data file in the current directory
+// mode "test" : your laptop will behave as a grid node running the analysis on data
+//               files downloaded from the grid
+// mode "terminate" : when your analysis is finished on the grid iterate calls with this mode
+//                    until your jobs are merged then make a final call with this mode and
+//                    gridMerge kFALSE to bring home your results
+
+void runAnalysis(const char *mode = "grid", Bool_t gridMerge = kTRUE)
 {
     // set if you want to run the analysis locally (kTRUE), or on grid (kFALSE)
-    Bool_t local = kTRUE;
+    Bool_t local = (TString(mode).EqualTo("local")) ? kTRUE : kFALSE;
     // if you run on grid, specify test mode (kTRUE) or full grid model (kFALSE)
-    Bool_t gridTest = kTRUE;
+    Bool_t gridTest = (TString(mode).EqualTo("test")) ? kTRUE : kFALSE;
     
     // since we will compile a class, tell root where to look for headers  
 #if !defined (__CINT__) || defined (__CLING__)
@@ -62,9 +79,8 @@ void runAnalysis()
         alienHandler->SetAnalysisSource("AliAnalysisTaskMyTask.cxx");
         // select the aliphysics version. all other packages
         // are LOADED AUTOMATICALLY!
-        alienHandler->SetAliPhysicsVersion("vAN-20181028_ROOT6-1");
-        // set the Alien API version
-        alienHandler->SetAPIVersion("V1.1x");
+        alienHandler->SetAliPhysicsVersion("vAN-20190122_ROOT6-1");
+
         // select the input data
         alienHandler->SetGridDataDir("/alice/data/2015/LHC15o");
         alienHandler->SetDataPattern("*pass1/AOD194/*AOD.root");
@@ -85,8 +101,8 @@ void runAnalysis()
         // after re-running the jobs in SetRunMode("terminate") 
         // (see below) mode, set SetMergeViaJDL(kFALSE) 
         // to collect final results
-        alienHandler->SetMaxMergeStages(1);
-        alienHandler->SetMergeViaJDL(kTRUE);
+        alienHandler->SetMaxMergeStages(2);
+        alienHandler->SetMergeViaJDL(gridMerge);
 
         // define the output folders
         alienHandler->SetGridWorkingDir("myWorkingDir");


### PR DESCRIPTION
Hi  @Redmer,

just if you want to consider it. 

I was not able to run the task with root5 so, I decided to adapt it.
Also I modified a little bit the runAnalysis in the way I use to do it.
With these changes
- runAnalysis("test") - test as a grid node
- runAnalysis("local") - test locally, requires a local AliAOD.root
- runAnalysis() - grid analysis, merge via JDL
- runAnalysis("terminate") - iterate grid merge until full merge
- runAnalysis("terminate",kFALSE) - bring home merged grid results and make the final merge

Hope it helps!